### PR TITLE
params-encode data not the triggering keyword

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -132,7 +132,7 @@
                                             (gh-api-expand-resource
                                              api resource)
                                             (if params
-                                                (gh-api-params-encode params)
+                                                (gh-api-params-encode data)
                                               ""))
                                :headers (if (eq fmt :form)
                                             '(("Content-Type" . "application/x-www-form-urlencoded")))


### PR DESCRIPTION
And is this actually required?:

```
 :data (or ... (and (eq fmt :form) (gh-api-form-encode data))
```
