### PR TITLE
support renaming of repos

### DIFF
--- a/gh-repos.el
+++ b/gh-repos.el
@@ -42,9 +42,9 @@
 ;;;###autoload
 (defclass gh-repos-repo-stub (gh-object)
   ((name :initarg :name)
-   (description :initarg :description :initform nil)
-   (homepage :initarg :homepage :initform nil)
-   (private :initarg :private :initform nil))
+   (description :initarg :description)
+   (homepage :initarg :homepage)
+   (private :initarg :private))
   "Class for user-created repository objects")
 
 (defmethod gh-object-read-into ((stub gh-repos-repo-stub) data)
@@ -142,9 +142,12 @@
         (has_wiki (plist-member caps :wiki))
         (has_downloads (plist-member caps :downloads)))
     `(("name" . ,(or name (oref repo :name)))
-      ("homepage" . ,(oref repo :homepage))
-      ("description" . ,(oref repo :description))
-      ("public" . ,(not (oref repo :private)))
+      ,@(when (slot-boundp repo :homepage)
+	  (list (cons "homepage" (oref repo :homepage))))
+      ,@(when (slot-boundp repo :description)
+	  (list (cons "description" (oref repo :description))))
+      ,@(when (slot-boundp repo :private)
+	  (list (cons "public" (not (oref repo :private)))))
       ,@(when has_issues
           (list (cons "has_issues" (plist-get caps :issues))))
       ,@(when has_wiki


### PR DESCRIPTION
By the way, why are some settings changed by changing the `gh-repos-repo-stub` object, while `has_*` directly using `CAPS`? Maybe because github doesn't return these when GETting `/repos/:user/:repo`? Shouldn't the repo classes have these slots anyway?

I think it would be better if `homepage`, `description` and `public` would behave the same way `name` does after my changes: use the value from `CAPS` (which then should be renamed) or if that is not set the value from the repo object.

Uh uh, just noticed a second related bug - patch and description follows.
