### PR TITLE
git 1.7.10 include directive and Local GitHub Config

### DIFF
--- a/gh-common.el
+++ b/gh-common.el
@@ -78,7 +78,7 @@
                      (substring string 0 (- (length string) 1)))))
         (git (executable-find "git")))
   (funcall strip (shell-command-to-string
-                  (concat git " config --global github." key)))))
+                  (concat git " config github." key)))))
 
 (defun gh-set-config (key value)
   "Sets a GitHub specific value to the global Git config."


### PR DESCRIPTION
The git 1.7.10 include directive [1] allows you to include external files from your .gitconfig. But these directives are not read by `git config --global github.user`, only by `git config github.user`.

In light of this, I think it makes sense for gh.el to use the latter rather than the former. Are there any cases where this will break that I'm not thinking of?
1. https://github.com/gitster/git/commit/9b25a0b52e09400719366f0a33d0d0da98bbf7b0
