### PR TITLE
add a note to new github oauth requests

### DIFF
--- a/gh-oauth.el
+++ b/gh-oauth.el
@@ -98,7 +98,9 @@
 (defmethod gh-oauth-auth-new ((api gh-oauth-api) &optional scopes)
   (gh-api-authenticated-request
    api (gh-object-reader (oref api auth-cls)) "POST"
-   (format "/authorizations") (list (cons 'scopes scopes))))
+   (format "/authorizations") (list (cons 'scopes scopes)
+                                    (cons 'note (format "gh.el - %s"
+                                                        (system-name))))))
 
 (defmethod gh-oauth-auth-update ((api gh-oauth-api) id &optional scopes)
   (gh-api-authenticated-request


### PR DESCRIPTION
By default new oauth tokens appears as `GitHub API` but it seems worth using `gh.el - <hostname>` as a better nomenclature.  This allows one to know which keys to revoke in their "Authorized Applications" tab in cases where they would like to.
