### PR TITLE
constuctor(gh-repos-repo): set slots NAME, OWNER from arg NEWNAME

### DIFF
--- a/gh-repos.el
+++ b/gh-repos.el
@@ -68,6 +68,7 @@
    (svn-url :initarg :svn-url)
    (mirror-url :initarg :mirror-url)
    (owner :initarg :owner :initform nil)
+   (full-name :initarg full-name)
    (language :initarg :language)
    (fork :initarg :fork)
    (forks :initarg :forks)
@@ -87,6 +88,19 @@
    (parent-cls :allocation :class :initform gh-repos-repo)
    (source-cls :allocation :class :initform gh-repos-repo))
   "Class for GitHub repositories")
+
+(defmethod constructor :static ((repo gh-repos-repo) newname &rest args)
+  (let ((obj (call-next-method)))
+    (when (and (not (slot-boundp obj 'name))
+               (not (oref obj owner)))
+      (with-slots (name owner)
+          obj
+        (when (slot-boundp obj 'full-name)
+          (setq newname (oref obj :full-name)))
+        (when (string-match "^\\([^/]+\\)/\\([^/]+\\)$" newname)
+          (setq name (match-string 2 newname)
+                owner (gh-user "owner" :login (match-string 1 newname))))))
+    obj))
 
 (defmethod gh-object-read-into ((repo gh-repos-repo) data)
   (call-next-method)


### PR DESCRIPTION
Set slot NAME and OWNER from the constructor argument NEWNAME if that
has the from "<OWNER>/<NAME>".  Actually, if the new slot FULL-NAME is
set in the constructor arguments use that instead.

This allows writing less to get an gh-repos-repo object suitable for
any api request.  Instead of

```
(gh-repos-repo "repo" :name "<NAME>"
               :owner (gh-user "owner" :login "<OWNER>"))
```

which is to long, simply

```
(gh-repos-repo "repo" :full-name "<OWNER>/<NAME>")
```

or even

```
(gh-repos-repo "<OWNER>/<NAME>")
```

can be used now.
