### PR TITLE
make dependency on logito optional

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -39,7 +39,7 @@
 (require 'gh-auth)
 (require 'gh-cache)
 
-(require 'logito)
+(require 'logito nil t)
 
 (defgroup gh-api nil
   "Github API."
@@ -64,7 +64,9 @@
   "Github API")
 
 (defmethod logito-log ((api gh-api) level tag string &rest objects)
-  (apply 'logito-log (oref api :log) level tag string objects))
+  (if (require 'logito nil t)
+      (apply 'logito-log (oref api :log) level tag string objects)
+    (error "Cannot open load file `logito' required for logging in `gh'")))
 
 (defmethod constructor :static ((api gh-api) newname &rest args)
   (call-next-method))


### PR DESCRIPTION
Currently `gh` does not actually make use of `logito` (as far as I can tell) so it makes no sense to depend on it.

I did not edit `gh-pkg.el` but think it would make sense to drop `logitio` from the dependencies. Unfortunately `package.el` does not differentiate between hard and soft dependencies.
