### PR TITLE
make use of library request.el

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     fi
   - pip install --use-mirrors virtualenv-emacs
   - virtualenv_install_emacs --with-emacs=`which "$EMACS"` --marmalade
-  - elpa-get eieio pcache logito mocker
+  - elpa-get eieio pcache logito mocker request
   - emacs --version
 script:
   make test

--- a/gh-pkg.el
+++ b/gh-pkg.el
@@ -1,2 +1,2 @@
 (define-package "gh" "%VERSION%" "A GitHub library for Emacs"
-  '((eieio "1.3") (pcache "0.2.3") (logito "0.1")))
+  '((eieio "1.3") (pcache "0.2.3") (logito "0.1") (request "0.2.0")))


### PR DESCRIPTION
You probably don't want to merge this as-is but I think this is a good first step. I have done only little testing but already use this for the Emacsmirror. So far things look good.

This doesn't really make proper use of `request.el` yet but even in the current form it is a big improvement because when using the `curl` backend I don't constantly get errors any more like I did with `url.el`.
1. The `gh-request-` prefix is used for some new functions. But the names of some old and new functions should be reconsidered. Also did not change the library name.
2. Handling of retries and paging should be handled in `request`. I don't think it supports that yet, so we have to keep implementing that in `gh`.
3. Paging can very easily exceed `max-lisp-eval-depth` and `max-specpdl-size`.
4. `gh-url-response` no longer supports callbacks. This was only used for `pcache` and simply calling `pcache-put` directly after making the request is good enough for that purpose.
