### PR TITLE
Explicitly bind `url-privacy-level' to avoid accidentally omitting User-Agent header.

### DIFF
--- a/gh-url.el
+++ b/gh-url.el
@@ -158,7 +158,8 @@
   (concat "?" (gh-url-form-encode form)))
 
 (defmethod gh-url-run-request ((req gh-url-request) &optional resp)
-  (let ((url-request-method (oref req :method))
+  (let ((url-privacy-level 'high)
+        (url-request-method (oref req :method))
         (url-request-data (oref req :data))
         (url-request-extra-headers (oref req :headers))
         (url (concat (oref req :url)


### PR DESCRIPTION
GitHub API always requires a User-Agent header to be sent. If the Emacs user
has decided to configure `url-privacy-level' such that it will omit
User-Agent, gh.el will fail for everything it does.
