### PR TITLE
Ensure a valid github profile is chosen.

### DIFF
--- a/gh-profile.el
+++ b/gh-profile.el
@@ -90,7 +90,7 @@ to here."
 (defun gh-profile-completing-read ()
   (let ((profiles (mapcar #'car gh-profile-alist)))
     (if (> (length profiles) 1)
-        (completing-read "Github profile: " profiles)
+        (completing-read "Github profile: " profiles nil t nil nil (first profiles))
       (car profiles))))
 
 (defun gh-profile-get-remote-profile (remote-url)


### PR DESCRIPTION
I was seeing the following error when I had more than one github profile:

```
Invalid slot type: gh-gist-api, :base, string, nil
```

I tracked it down to this completing-read not requiring valid input.
This change makes it so:
- If the user inputs nothing, it returns the first profile in the list.
- The choice must be in the list of profiles.

Meanwhile, for people using ido-ubiquitous, this is also an acceptable
workaround:

(setq ido-ubiquitous-enable-old-style-default nil)
