### PR TITLE
added basic docs for issues

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Contents:
    :maxdepth: 2
 
    intro
-
+   issues
 
 Indices and tables
 ==================

--- a/docs/source/issues.rst
+++ b/docs/source/issues.rst
@@ -1,0 +1,53 @@
+========
+ Issues
+========
+
+gh.el is built on top of Eieio. The scope of this client library is to provide
+plumbing primitives that will allow full use of the GitHub API.
+
+
+gh.el allows access to GitHub issues.
+
+First, connect to the API::
+
+  (gh-issues-api "api")
+
+This will OAuth connect to GitHub and return an API connection object.
+
+The API connection object can be passed to issues methods::
+
+  (gh-issues-issue-list (gh-issues-api "API") "sigma" "gh.el")
+
+The issue list has a class `gh-api-paged-response` which has a member
+`data` which can be used to retrieve the data sent back from GitHub::
+
+  (oref
+    (gh-issues-issue-list (gh-issues-api "API") "sigma" "gh.el")
+    data)
+
+This returns a list of items of class `gh-issues-issue`. You can
+further `oref` those to get data. Putting it all together we might have::
+
+
+  (defun fill-string (str)
+    (with-temp-buffer
+      (insert str)
+      (fill-paragraph)
+      (buffer-string)))
+
+  (mapcar
+     (lambda (issue)
+       (insert
+        (format
+         "#%s %s -- %s\n%s\n\n"
+         (oref it number) ; the issue number
+         (oref it created_at) ; the data
+         (fill-string (oref it title)) ; the title, filled
+         (fill-string
+           (replace-regexp-in-string
+              "\r" "\n" (oref it body)))))  ; the body filled
+       (oref
+        (gh-issues-issue-list ghcon "sigma" "gh.el")
+        data)))
+
+


### PR DESCRIPTION
This is very basic stuff but it's what I found out.

I tried to generate docs for you based on [this](https://github.com/flycheck/sphinxcontrib-emacs/blob/master/doc/guide/quickstart.rst) but it seems you have to install it and then that would conflict with your own sphinx infrastructure.

So I left that bit alone.
