### PR TITLE
Added avatar-url to the commons user class

### DIFF
--- a/gh-common.el
+++ b/gh-common.el
@@ -66,16 +66,18 @@
 (defclass gh-user (gh-object)
   ((login :initarg :login)
    (id :initarg :id)
+   (avatar-url :initarg :avatar-url)
    (gravatar-url :initarg :gravatar-url)
    (url :initarg :url))
   "Github user object")
 
 (defmethod gh-object-read-into ((user gh-user) data)
   (call-next-method)
-  (with-slots (login id gravatar-url url)
+  (with-slots (login id avatar-url gravatar-url url)
       user
     (setq login (gh-read data 'login)
           id (gh-read data 'id)
+          avatar-url (gh-read data 'avatar_url)
           gravatar-url (gh-read data 'gravatar_url)
           url (gh-read data 'url))))
 


### PR DESCRIPTION
I'm working on a package that would like to make use of the GitHub `avatar_url`, would it be possible to add this to the `gh-user` class and deserialize it?