### PR TITLE
Pull 100 PRs at once in list GET

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -158,6 +158,7 @@
       (let ((req (oref resp :-req)))
         (oset resp :data-received nil)
         (oset req :url next)
+        (oset req :query nil)
         (gh-url-run-request req resp)))))
 
 (defmethod gh-api-authenticated-request

--- a/gh-pulls.el
+++ b/gh-pulls.el
@@ -143,7 +143,8 @@
 (defmethod gh-pulls-list ((api gh-pulls-api) user repo)
   (gh-api-authenticated-request
    api (gh-object-list-reader (oref api req-cls)) "GET"
-   (format "/repos/%s/%s/pulls" user repo)))
+   (format "/repos/%s/%s/pulls" user repo)
+   nil `(("per_page" . "100"))))
 
 (defmethod gh-pulls-get ((api gh-pulls-api) user repo id)
   (gh-api-authenticated-request


### PR DESCRIPTION
@alexander-yakushev More performance improvements, hooray. :smile: GitHub's API provides 30 items at a time by default, but you can ask for up to 100. This will save us some round-trips on big repos. I also needed to fix a few bugs around paginated requests to get this to work; I'll comment on what each of these is doing.