### PR TITLE
Add head and base to pull stub

### DIFF
--- a/gh-pulls.el
+++ b/gh-pulls.el
@@ -96,9 +96,7 @@
    (commits :initarg :commits)
    (additions :initarg :additions)
    (deletions :initarg :deletions)
-   (changed-files :initarg :changed-files)
-   (head :initarg :head :initform nil :marshal-type gh-repos-ref)
-   (base :initarg :base :initform nil :marshal-type gh-repos-ref))
+   (changed-files :initarg :changed-files))
   "Git pull requests API")
 
 (defmethod gh-pulls-req-to-new ((req gh-pulls-request))

--- a/gh-pulls.el
+++ b/gh-pulls.el
@@ -82,7 +82,9 @@
    (created-at :initarg :created-at)
    (updated-at :initarg :updated-at)
    (closed-at :initarg :closed-at)
-   (merged-at :initarg :merged-at)))
+   (merged-at :initarg :merged-at)
+   (head :initarg :head :initform nil :marshal-type gh-repos-ref)
+   (base :initarg :base :initform nil :marshal-type gh-repos-ref)))
 
 ;;;###autoload
 (gh-defclass gh-pulls-request (gh-pulls-request-stub)


### PR DESCRIPTION
Redirecting from #59 to `next` branch

These fields are already provided in the list response, this PR sticks them to the created stub object for use.

By providing this information in the stub, we're able to eliminate subsequent GET calls to individual PRs and get some pretty big performance improvements in magit-gh-pulls. Relevant downstream PR is here: sigma/magit-gh-pulls#75