### PR TITLE
Fixed null content API bug

### DIFF
--- a/gh-gist.el
+++ b/gh-gist.el
@@ -97,8 +97,13 @@
                            (oref f :content)) (oref gist :files)))))
 
 (defmethod gh-gist-gist-file-to-obj ((file gh-gist-gist-file))
-  `(,(oref file :filename) . (("filename" . ,(oref file :filename))
-                              ("content" . ,(oref file :content)))))
+  (let* ((filename (oref file :filename))
+        (content (oref file :content))
+        (file (if content
+                  `(("filename" . ,filename)
+                    ("content"  . ,content))
+                nil)))
+    (cons filename file)))
 
 (defmethod gh-gist-list ((api gh-gist-api) &optional username)
   (gh-api-authenticated-request


### PR DESCRIPTION
Rebased #63 onto *next* since tests weren't passing on *master*.
***
This came up when I was debugging defunkt/gist.el#74
* * *
Calling `gist-mode-write-file` from a git-mode buffer or
`gist-edit-current-description` from
the *github:gists* (i.e. `git-list`) buffer was returning the following
error: `byte-code: Invalid slot type: gh-gist-gist, id, string, nil`.

This error was because the GitHub v3 API does not allow null "content"
properties.  This functions were setting this slot to nil to delete the
file.  The GitHub v3 API requires a null object associated with the
filename to delete a gist file (see
https://developer.github.com/v3/gists/#edit-a-gist).

To fix this, `gh-gist-gist-file-to-obj` was updated to return length one
lists containing the filename when the :content slot is nil.