### PR TITLE
Remove setting of unbound variable in gh-search.el

### DIFF
--- a/gh-search.el
+++ b/gh-search.el
@@ -44,7 +44,6 @@
 (defmacro gh-search-process-method-builder (method-name class-symbol)
   `(defmethod ,method-name ((search-api gh-search-api) data)
      (unless (listp data)
-       (setq the-data data)
        (error "Did not recieve a list from the search query"))
      (let ((items (assoc 'items data)))
        (unless items


### PR DESCRIPTION
This statement was used for debugging during development and is no
longer needed.