### PR TITLE
Fixes #85: convert post data and auth token to unibytes

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -133,7 +133,7 @@
       (json-read-from-string repr))))
 
 (defun gh-api-json-encode (json)
-  (json-encode-list json))
+  (encode-coding-string (json-encode-list json) 'utf-8))
 
 (defmethod gh-url-response-set-data ((resp gh-api-response) data)
   (call-next-method resp (gh-api-json-decode data)))

--- a/gh-auth.el
+++ b/gh-auth.el
@@ -162,7 +162,8 @@
 (defmethod gh-auth-modify-request ((auth gh-oauth-authenticator) req)
   (object-add-to-list req :headers
                       (cons "Authorization"
-                            (format "token %s" (oref auth :token))))
+                            (encode-coding-string
+                             (format "token %s" (oref auth :token)) 'utf-8)))
   req)
 
 (provide 'gh-auth)


### PR DESCRIPTION
Hi @sigma 

This is a solution for #85. Since emacs-25.1, `url-retrieve` returns error if the request data contains multibyte characters. I found that the followings can contain multibyte characters.

* post JSON data which can includes buffer content or description for Gist
* Authorization token which is included in the extra header

I added `encode-coding-string` to each portion, and confirmed the problem was fixed. I'm not sure this is the best solution, but it works for posting Gist and adding description at least.