### PR TITLE
set async props of request from api object

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -219,7 +219,8 @@
                                          (and (eq fmt :form)
                                               (gh-url-form-encode data))
                                          "")
-                               :page-limit page-limit)))))
+                               :page-limit page-limit
+                               :async (not (oref api sync)))))))
     (cond ((and has-value ;; got value from cache
                 (not is-outdated))
            (make-instance 'gh-api-response :data-received t :data value))


### PR DESCRIPTION
set `gh-api-paged-request`'s async property from `gh-api`'s `sync` property.