### PR TITLE
gh-sanitize-content: new function

### DIFF
--- a/gh-common.el
+++ b/gh-common.el
@@ -79,6 +79,19 @@ Emacs. This makes a difference when running with TRAMP."
     (with-output-to-string
       (apply runner git nil standard-output nil args))))
 
+(defun gh-sanitize-content (content)
+  "Remove all non-unicode characters. This can be used to
+sanitize API calls that need to handle potentially dirty data."
+  (let (res skipped)
+    (mapc (lambda (c)
+            (if (eq 'Cn (get-char-code-property c 'general-category))
+                (setq skipped t)
+              (push c res)))
+          content)
+    (when skipped
+      (warn "Content contained non-unicode characters"))
+    (apply #'string (nreverse res))))
+
 ;;; Base classes for common objects
 
 ;;;###autoload

--- a/gh-gist.el
+++ b/gh-gist.el
@@ -88,6 +88,12 @@
    (url :initarg :url :marshal ((alist . raw_url)))
    (content :initarg :content)))
 
+(defmethod constructor :static ((file gh-gist-gist-file) &rest args)
+  (let ((obj (call-next-method)))
+    (when (oref obj :content)
+      (oset obj :content (gh-sanitize-content (oref obj :content))))
+    obj))
+
 (defmethod gh-gist-gist-to-obj ((gist gh-gist-gist-stub))
   (let ((files (mapcar #'gh-gist-gist-file-to-obj (oref gist :files))))
     `(("description" . ,(oref gist :description))


### PR DESCRIPTION
This function removes all non-unicode characters from arbitrary content. This
can be used to ensure that the API call will not fail server-side to parse the
request.

Since this is a lossy operation, warn the user.

Use-case: buffers that we want to gist can contain arbitrary content, but we
still need to encode it.

This closes defunkt/gist.el#86