### PR TITLE
Fix issues with Emacs 29 compatibility

### DIFF
--- a/gh-api.el
+++ b/gh-api.el
@@ -1,4 +1,4 @@
-;;; gh-api.el --- api definition for gh.el
+;;; gh-api.el --- api definition for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-auth.el
+++ b/gh-auth.el
@@ -1,4 +1,4 @@
-;;; gh-auth.el --- authentication for gh.el
+;;; gh-auth.el --- authentication for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-cache.el
+++ b/gh-cache.el
@@ -1,4 +1,4 @@
-;;; gh-cache.el --- caching for gh.el
+;;; gh-cache.el --- caching for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-comments.el
+++ b/gh-comments.el
@@ -1,4 +1,4 @@
-;;; gh-comments.el --- support for comment-enabled APIs
+;;; gh-comments.el --- support for comment-enabled APIs -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014-2015  Yann Hodique
 

--- a/gh-common.el
+++ b/gh-common.el
@@ -1,4 +1,4 @@
-;;; gh-common.el --- common objects for gh.el
+;;; gh-common.el --- common objects for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-common.el
+++ b/gh-common.el
@@ -109,8 +109,7 @@ sanitize API calls that need to handle potentially dirty data."
 
 (cl-defmethod gh-object-read ((obj gh-object) data)
   (when data
-    (gh-object-read-into obj data))
-  target)
+    (gh-object-read-into obj data)))
 
 (cl-defmethod gh-object-reader ((obj gh-object))
   (apply-partially 'gh-object-read obj))

--- a/gh-common.el
+++ b/gh-common.el
@@ -1,4 +1,4 @@
-;;; gh-common.el --- common objects for gh.el -*- lexical-binding: t; -*-
+;;; gh-common.el --- common objects for gh.el -*- lexical-binding: t; no-byte-compile: t-*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-gist.el
+++ b/gh-gist.el
@@ -1,4 +1,4 @@
-;;; gh-gist.el --- gist module for gh.el
+;;; gh-gist.el --- gist module for gh.el  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-issue-comments.el
+++ b/gh-issue-comments.el
@@ -1,4 +1,4 @@
-;;; gh-issue-comments.el --- issue comments api for github
+;;; gh-issue-comments.el --- issue comments api for github -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014 Travis Thieman
 

--- a/gh-issues.el
+++ b/gh-issues.el
@@ -1,4 +1,4 @@
-;;; gh-issues.el --- issues api for github
+;;; gh-issues.el --- issues api for github -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014-2015  Yann Hodique
 ;; Copyright (C) 2014 Travis Thieman

--- a/gh-oauth.el
+++ b/gh-oauth.el
@@ -1,4 +1,4 @@
-;;; gh-oauth.el --- oauth module for gh.el
+;;; gh-oauth.el --- oauth module for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012  Yann Hodique
 

--- a/gh-orgs.el
+++ b/gh-orgs.el
@@ -1,4 +1,4 @@
-;;; gh-org.el --- orgs module for gh.el
+;;; gh-org.el --- orgs module for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012  Yann Hodique
 

--- a/gh-profile.el
+++ b/gh-profile.el
@@ -1,4 +1,4 @@
-;;; gh-profile.el --- profile support for gh.el
+;;; gh-profile.el --- profile support for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013  Yann Hodique
 

--- a/gh-pull-comments.el
+++ b/gh-pull-comments.el
@@ -1,4 +1,4 @@
-;;; gh-pull-comments.el --- pull request comments api for github
+;;; gh-pull-comments.el --- pull request comments api for github -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014 Toni Reina
 

--- a/gh-pull-comments.el
+++ b/gh-pull-comments.el
@@ -53,7 +53,7 @@
   (define-obsolete-function-alias
       'gh-pull-comments-req-to-update 'gh-comment-req-to-update ver)
   (define-obsolete-function-alias
-      'gh-pull-comments-req-to-create 'gh-pulls-comment-req-to-create)
+      'gh-pull-comments-req-to-create 'gh-pulls-comment-req-to-create ver)
 
   (define-obsolete-function-alias
       'gh-pull-comments-list 'gh-pulls-comments-list ver)

--- a/gh-pulls.el
+++ b/gh-pulls.el
@@ -1,4 +1,4 @@
-;;; gh-pulls.el --- pull requests module for gh.el
+;;; gh-pulls.el --- pull requests module for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-repos.el
+++ b/gh-repos.el
@@ -1,4 +1,4 @@
-;;; gh-repos.el --- repos module for gh.el
+;;; gh-repos.el --- repos module for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 

--- a/gh-search.el
+++ b/gh-search.el
@@ -1,4 +1,4 @@
-;;; gh-search.el --- repository search for gh.el
+;;; gh-search.el --- repository search for gh.el -*- lexical-binding: t; -*-
 ;; Copyright (C) 2016  Ivan Malison
 
 ;; Author: Ivan Malison <IvanMalison@gmail.com>

--- a/gh-url.el
+++ b/gh-url.el
@@ -1,4 +1,4 @@
-;;; gh-url.el --- url wrapper for gh.el
+;;; gh-url.el --- url wrapper for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2012  Yann Hodique
 

--- a/gh-users.el
+++ b/gh-users.el
@@ -1,4 +1,4 @@
-;;; gh-users.el --- users module for gh.el
+;;; gh-users.el --- users module for gh.el -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013  Yann Hodique
 

--- a/gh.el
+++ b/gh.el
@@ -1,4 +1,4 @@
-;;; gh.el --- Github API client libraries
+;;; gh.el --- Github API client libraries -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011  Yann Hodique
 


### PR DESCRIPTION
Fix issues with Emacs 29 compatibility:
- enable local bindings
- [remove](https://github.com/sigma/gh.el/commit/1ff7378f0db91343f143bcb321eb48eb9ce9fce7) reference to the free variable in `gh-object-read` method
- add a missing argument to define-obsolete-function-alias
- [disable](https://github.com/sigma/gh.el/commit/d081ded977c31446f67ecdd1678a7adfb10ed636) byte compile gh-common