### PR TITLE
Github token as a function

### DIFF
--- a/gh-auth.el
+++ b/gh-auth.el
@@ -84,6 +84,7 @@
                              :token))))
         (setq token (or tok (read-string "GitHub OAuth token: ")))
         (gh-set-config "oauth-token" token)))
+    (when (functionp token) (setq token (funcall token)))
     (gh-auth-remember profile :token token)
     token))
 


### PR DESCRIPTION
Allow to set a function as token in `gh-profile-alist`. The function should evaluate to return a string. 