### PR TITLE
first is obsolete since 27.1; use cl-first instead.

### DIFF
--- a/gh-profile.el
+++ b/gh-profile.el
@@ -89,7 +89,7 @@ to here."
 (defun gh-profile-completing-read ()
   (let ((profiles (mapcar #'car gh-profile-alist)))
     (if (> (length profiles) 1)
-        (completing-read "Github profile: " profiles nil t nil nil (first profiles))
+        (completing-read "Github profile: " profiles nil t nil nil (cl-first profiles))
       (car profiles))))
 
 (defun gh-profile-get-remote-profile (remote-url)


### PR DESCRIPTION
Hello,

When I have more profiles, it throws an error `Symbol’s function definition is void: first `.
This patch will resolve this issue.

Thanks